### PR TITLE
Fix data type for torch v0.4.1

### DIFF
--- a/a2c_ppo_acktr/algo/gail.py
+++ b/a2c_ppo_acktr/algo/gail.py
@@ -119,9 +119,11 @@ class ExpertDataset(torch.utils.data.Dataset):
         idx = perm[:num_trajectories]
 
         self.trajectories = {}
-
+        
+        # See https://github.com/pytorch/pytorch/issues/14886
+        # .long() for fixing bug in torch v0.4.1
         start_idx = torch.randint(
-            0, subsample_frequency, size=(num_trajectories, ))
+            0, subsample_frequency, size=(num_trajectories, )).long()
 
         for k, v in all_trajectories.items():
             data = v[idx]


### PR DESCRIPTION
PyTorch v0.4.1 returns float32 on calling `torch.randint()` (see this: https://github.com/pytorch/pytorch/issues/14886).