### PR TITLE
Fix GAIL expert dataloader

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,13 +79,15 @@ def main():
         file_name = os.path.join(
             args.gail_experts_dir, "trajs_{}.pt".format(
                 args.env_name.split('-')[0].lower()))
-
+        
+        expert_dataset = gail.ExpertDataset(
+            file_name, num_trajectories=4, subsample_frequency=20)
+        drop_last = len(expert_dataset) > args.gail_batch_size
         gail_train_loader = torch.utils.data.DataLoader(
-            gail.ExpertDataset(
-                file_name, num_trajectories=4, subsample_frequency=20),
+            dataset=expert_dataset,
             batch_size=args.gail_batch_size,
             shuffle=True,
-            drop_last=True)
+            drop_last=drop_last)
 
     rollouts = RolloutStorage(args.num_steps, args.num_processes,
                               envs.observation_space.shape, envs.action_space,


### PR DESCRIPTION
Set drop_last=True only if the dataset size is more than GAIL batch size (otherwise it just returns an empty dataloader). See example below:

```python
>>> from torch.utils.data.sampler import BatchSampler, SequentialSampler
>>> list(BatchSampler(SequentialSampler(range(10)), batch_size=11, drop_last=True))
[]

```