### PR TITLE
replace baselines dependencies

### DIFF
--- a/a2c_ppo_acktr/algo/gail.py
+++ b/a2c_ppo_acktr/algo/gail.py
@@ -6,8 +6,7 @@ import torch.nn.functional as F
 import torch.utils.data
 from torch import autograd
 
-from baselines.common.running_mean_std import RunningMeanStd
-
+from stable_baselines3.common.running_mean_std import RunningMeanStd
 
 class Discriminator(nn.Module):
     def __init__(self, input_dim, hidden_dim, device):

--- a/a2c_ppo_acktr/envs.py
+++ b/a2c_ppo_acktr/envs.py
@@ -5,12 +5,11 @@ import numpy as np
 import torch
 from gym.spaces.box import Box
 
-from baselines import bench
-from baselines.common.atari_wrappers import make_atari, wrap_deepmind
-from baselines.common.vec_env import VecEnvWrapper
-from baselines.common.vec_env.dummy_vec_env import DummyVecEnv
-from baselines.common.vec_env.shmem_vec_env import ShmemVecEnv
-from baselines.common.vec_env.vec_normalize import \
+from stable_baselines3.common.monitor import Monitor
+from stable_baselines3.common.atari_wrappers import (
+    NoopResetEnv, MaxAndSkipEnv, EpisodicLifeEnv, FireResetEnv, WarpFrame, ClipRewardEnv)
+from stable_baselines3.common.vec_env import VecEnvWrapper, DummyVecEnv, SubprocVecEnv
+from stable_baselines3.common.vec_env.vec_normalize import \
     VecNormalize as VecNormalize_
 
 try:
@@ -40,7 +39,8 @@ def make_env(env_id, seed, rank, log_dir, allow_early_resets):
         is_atari = hasattr(gym.envs, 'atari') and isinstance(
             env.unwrapped, gym.envs.atari.atari_env.AtariEnv)
         if is_atari:
-            env = make_atari(env_id)
+            env = NoopResetEnv(env, noop_max=30)
+            env = MaxAndSkipEnv(env, skip=4)
 
         env.seed(seed + rank)
 
@@ -48,14 +48,18 @@ def make_env(env_id, seed, rank, log_dir, allow_early_resets):
             env = TimeLimitMask(env)
 
         if log_dir is not None:
-            env = bench.Monitor(
+            env = Monitor(
                 env,
                 os.path.join(log_dir, str(rank)),
                 allow_early_resets=allow_early_resets)
 
         if is_atari:
             if len(env.observation_space.shape) == 3:
-                env = wrap_deepmind(env)
+                env = EpisodicLifeEnv(env)
+                if "FIRE" in env.unwrapped.get_action_meanings():
+                    env = FireResetEnv(env)
+                env = WarpFrame(env, width=84, height=84)
+                env = ClipRewardEnv(env)
         elif len(env.observation_space.shape) == 3:
             raise NotImplementedError(
                 "CNN models work only for atari,\n"
@@ -86,7 +90,7 @@ def make_vec_envs(env_name,
     ]
 
     if len(envs) > 1:
-        envs = ShmemVecEnv(envs, context='fork')
+        envs = SubprocVecEnv(envs)
     else:
         envs = DummyVecEnv(envs)
 


### PR DESCRIPTION
`openai/baselines` has tensorflow and mujoco dependencies by default. Tensorflow installation is not necessary for scripts in this repo and mujoco is not very friendly to build. It might be quite desirable to remove these dependencies by using `stable_baselines3` as done in this PR.