### PR TITLE
ob_rms_to_obs_rms

### DIFF
--- a/a2c_ppo_acktr/envs.py
+++ b/a2c_ppo_acktr/envs.py
@@ -192,11 +192,11 @@ class VecNormalize(VecNormalize_):
         self.training = True
 
     def _obfilt(self, obs, update=True):
-        if self.ob_rms:
+        if self.obs_rms:
             if self.training and update:
-                self.ob_rms.update(obs)
-            obs = np.clip((obs - self.ob_rms.mean) /
-                          np.sqrt(self.ob_rms.var + self.epsilon),
+                self.obs_rms.update(obs)
+            obs = np.clip((obs - self.obs_rms.mean) /
+                          np.sqrt(self.obs_rms.var + self.epsilon),
                           -self.clipob, self.clipob)
             return obs
         else:

--- a/enjoy.py
+++ b/enjoy.py
@@ -49,14 +49,14 @@ env = make_vec_envs(
 render_func = get_render_func(env)
 
 # We need to use the same statistics for normalization as used in training
-actor_critic, ob_rms = \
+actor_critic, obs_rms = \
             torch.load(os.path.join(args.load_dir, args.env_name + ".pt"),
                         map_location='cpu')
 
 vec_norm = get_vec_normalize(env)
 if vec_norm is not None:
     vec_norm.eval()
-    vec_norm.ob_rms = ob_rms
+    vec_norm.obs_rms = obs_rms
 
 recurrent_hidden_states = torch.zeros(1,
                                       actor_critic.recurrent_hidden_state_size)

--- a/evaluation.py
+++ b/evaluation.py
@@ -5,7 +5,7 @@ from a2c_ppo_acktr import utils
 from a2c_ppo_acktr.envs import make_vec_envs
 
 
-def evaluate(actor_critic, ob_rms, env_name, seed, num_processes, eval_log_dir,
+def evaluate(actor_critic, obs_rms, env_name, seed, num_processes, eval_log_dir,
              device):
     eval_envs = make_vec_envs(env_name, seed + num_processes, num_processes,
                               None, eval_log_dir, device, True)
@@ -13,7 +13,7 @@ def evaluate(actor_critic, ob_rms, env_name, seed, num_processes, eval_log_dir,
     vec_norm = utils.get_vec_normalize(eval_envs)
     if vec_norm is not None:
         vec_norm.eval()
-        vec_norm.ob_rms = ob_rms
+        vec_norm.obs_rms = obs_rms
 
     eval_episode_rewards = []
 

--- a/main.py
+++ b/main.py
@@ -172,7 +172,7 @@ def main():
 
             torch.save([
                 actor_critic,
-                getattr(utils.get_vec_normalize(envs), 'ob_rms', None)
+                getattr(utils.get_vec_normalize(envs), 'obs_rms', None)
             ], os.path.join(save_path, args.env_name + ".pt"))
 
         if j % args.log_interval == 0 and len(episode_rewards) > 1:
@@ -189,8 +189,8 @@ def main():
 
         if (args.eval_interval is not None and len(episode_rewards) > 1
                 and j % args.eval_interval == 0):
-            ob_rms = utils.get_vec_normalize(envs).ob_rms
-            evaluate(actor_critic, ob_rms, args.env_name, args.seed,
+            obs_rms = utils.get_vec_normalize(envs).obs_rms
+            evaluate(actor_critic, obs_rms, args.env_name, args.seed,
                      args.num_processes, eval_log_dir, device)
 
 


### PR DESCRIPTION
The problem occurs in an environment where **obs_rms** is used because the variable **self.ob_rms** in the **VecNormalize class** in the **envs.py**  is not the same as **self.obs_rms** in the (from stable_baselines3.common.vec_env.vec_normalize import  **VecNormalize as VecNormalize_** ).