### PR TITLE
add h5py in requirement.txt and add conda intall atari in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ conda install pytorch torchvision -c soumith
 
 # Other requirements
 pip install -r requirements.txt
+
+# Gym Atari
+conda install -c conda-forge gym-atari
 ```
 
 ## Contributions

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ gym
 matplotlib
 pybullet
 stable-baselines3
+h5py


### PR DESCRIPTION
1. add h5py in requirement.txt
2. since pip install gym atari doesn't work, add conda install gym atari in readme